### PR TITLE
Return an error when aborting due to existing .orig file

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -940,6 +940,7 @@ class PatchSet(object):
         backupname = filename+b".orig"
         if exists(backupname):
           warning("can't backup original file to %s - aborting" % backupname)
+          errors += 1
         else:
           import shutil
           shutil.move(filename, backupname)


### PR DESCRIPTION
See https://github.com/techtonik/python-patch/issues/60 for a description of the issue and https://github.com/techtonik/python-patch/pull/61#issue-271513395 for the output of that test after applying this fix.